### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/plugins/httpapi/sfss.py
+++ b/plugins/httpapi/sfss.py
@@ -38,10 +38,10 @@ options:
 """
 
 import json
+from urllib.error import HTTPError
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import ConnectionError
-from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.plugins.httpapi import HttpApiBase
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import to_list
 

--- a/plugins/module_utils/network/sfss/utils/utils.py
+++ b/plugins/module_utils/network/sfss/utils/utils.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_empties
 )
@@ -261,28 +260,28 @@ def dict_to_set(sample_dict):
     # Generate a set with passed dictionary for comparison
     test_dict = {}
     if isinstance(sample_dict, dict):
-        for k, v in iteritems(sample_dict):
+        for k, v in sample_dict.items():
             if v is not None:
                 if isinstance(v, list):
                     if isinstance(v[0], dict):
                         li = []
                         for each in v:
-                            for key, value in iteritems(each):
+                            for key, value in each.items():
                                 if isinstance(value, list):
                                     each[key] = tuple(value)
-                            li.append(tuple(iteritems(each)))
+                            li.append(tuple(each.items()))
                         v = tuple(li)
                     else:
                         v = tuple(v)
                 elif isinstance(v, dict):
                     li = []
-                    for key, value in iteritems(v):
+                    for key, value in v.items():
                         if isinstance(value, list):
                             v[key] = tuple(value)
-                    li.extend(tuple(iteritems(v)))
+                    li.extend(tuple(v.items()))
                     v = tuple(li)
                 test_dict.update({k: v})
-        return_set = set(tuple(iteritems(test_dict)))
+        return_set = set(tuple(test_dict.items()))
     else:
         return_set = set(sample_dict)
     return return_set


### PR DESCRIPTION
# Description

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. Both uses in this collection have direct stdlib equivalents:

```python
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from urllib.error import HTTPError

-for k, v in iteritems(sample_dict):
+for k, v in sample_dict.items():
```

`six.moves.urllib.error.HTTPError` is the identical class on Python 3, and `six.iteritems(d)` is `iter(d.items())`. In `dict_to_set()` the results are consumed by `tuple()` / `set()` immediately, so iterating a view rather than an iterator produces identical output; no iterator is reused, and the in-place `each[key] = tuple(value)` assignment replaces an existing key and so cannot resize the dict.

# GitHub Issues

| GitHub Issue # |
| -------------- |
| N/A |

# ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

plugins/httpapi/sfss.py, plugins/module_utils/network/sfss/utils/utils.py

##### OUTPUT

Import-only and iteration-only change. The replaced name resolves to the same object:

```
from ansible.module_utils.six.moves.urllib.error import HTTPError as A
from urllib.error import HTTPError as B
A is B  ->  True
```

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A: no new logic)
- [ ] I have made corresponding changes to the documentation (N/A: no user-facing change)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A: no behaviour change on Python 3)
- [x] I have maintained backward compatibility

One thing worth flagging: `meta/runtime.yml` declares `requires_ansible: '>=2.9.10'` and the sanity matrix includes stable-2.9/2.10/2.11, whose import test can exercise Python 2.7. `urllib.error` is Python 3 only, where the old `six.moves` import was not. In practice those ansible-core versions are long EOL, but if you would rather keep them green, raising the `requires_ansible` floor alongside this would be the clean fix. Happy to do that here.
